### PR TITLE
Fixed compatibility issue with different versions of impacket.

### DIFF
--- a/smbmap.py
+++ b/smbmap.py
@@ -120,7 +120,10 @@ class CMDEXEC:
         logging.debug('StringBinding %s'%stringbinding)
         rpctransport = transport.DCERPCTransportFactory(stringbinding)
         rpctransport.set_dport(self.__port)
-        rpctransport.setRemoteHost(remoteHost)
+        if hasattr(rpctransport,'setRemoteHost'):
+            rpctransport.setRemoteHost(remoteHost)
+        else:
+            rpctransport.__dstip = remoteHost
         if hasattr(rpctransport,'preferred_dialect'):
             rpctransport.preferred_dialect(SMB_DIALECT)
         if hasattr(rpctransport, 'set_credentials'):


### PR DESCRIPTION
I ran into trouble with smbmap on the latest version of Kali Linux (2018.1), specifically with the -X argument, although it also occurred with other arguments that ultimately utilize the CMDEXEC function. The exact error:
`[!] SMBTransport instance has no attribute 'setRemoteHost'
(<type 'exceptions.AttributeError'>, 'smbmap.py', 894)`

The problem seems to be that setRemoteHost doesn't exist in newer versions of SMBTransport, as found in impacket. I wrote up a quick fix that checks for the presence of this function and utilizes it if it exists or manually sets __dstip otherwise.