### PR TITLE
syntax error with python 3

### DIFF
--- a/smbmap.py
+++ b/smbmap.py
@@ -1039,7 +1039,7 @@ if __name__ == "__main__":
     sgroup5.add_argument("--skip", default=False, action="store_true", help="Skip delete file confirmation prompt")
 
 
-    if len(sys.argv) is 1:
+    if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
 


### PR DESCRIPTION
When i used i have a syntax error message saying 
`/usr/bin/smbmap:1042: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(sys.argv) is 1:`
so i just made like my wonderful interpreter said me and now no more error message :D
look here, that's a change which come with python3.8 
http://qemu.11.n7.nabble.com/PATCH-trace-avoid-quot-is-quot-with-a-literal-Python-3-8-warnings-td689609.html