### PR TITLE
Add configparser to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 https://github.com/CoreSecurity/impacket/archive/impacket_0_9_20.zip
 pyasn1
 pycrypto
+configparser


### PR DESCRIPTION
Before and after
```
(venv) root@htb:~/smbmap# python ./smbmap.py
Traceback (most recent call last):
  File "./smbmap.py", line 10, in <module>
    import configparser
ImportError: No module named configparser
(venv) root@htb:~/smbmap# pip install configparser
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python
 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
Collecting configparser
  Downloading https://files.pythonhosted.org/packages/7a/2a/95ed0501cf5d8709490b1d3a3f9b5cf340da6c433f896bbe9ce08dbe6785/configparser-4.0.2-py2.py3-none-any.whl
Installing collected packages: configparser
Successfully installed configparser-4.0.2
(venv) root@htb:~/smbmap# python ./smbmap.py
usage: smbmap.py [-h] (-H HOST | --host-file FILE) [-u USERNAME] [-p PASSWORD]
                 [-s SHARE] [-d DOMAIN] [-P PORT] [-v] [-x COMMAND]
                 [--mode CMDMODE] [-L | -R [PATH] | -r [PATH]]
                 [-A PATTERN | -g] [--dir-only] [-q] [--depth DEPTH]
                 [-F PATTERN] [--search-path PATH] [--download PATH]
                 [--upload SRC DST] [--delete PATH TO FILE] [--skip]

SMBMap - Samba Share Enumerator | Shawn Evans - ShawnDEvans@gmail.com
```