### PR TITLE
Add file write check for WRITE permission

### DIFF
--- a/smbmap.py
+++ b/smbmap.py
@@ -26,6 +26,7 @@ from impacket.dcerpc.v5 import transport, scmr
 from impacket.dcerpc.v5.dcomrt import DCOMConnection
 from impacket.dcerpc.v5.dcom import wmi
 from impacket.dcerpc.v5.dtypes import NULL
+from impacket.smb3structs import FILE_WRITE_DATA
 
 import ntpath
 import cmd
@@ -791,6 +792,22 @@ class SMBMap():
                         fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
                         #print(exc_type, fname, exc_tb.tb_lineno)
                         sys.stdout.flush()
+                    if not canWrite:
+                        try:
+                            root = PERM_DIR.replace('/','\\')
+                            root = ntpath.normpath(root)
+                            self.create_file(host, share_name, root)
+                            share_tree[share_name]['privs'] = colored('READ, WRITE', 'green')
+                            canWrite = True
+                            try:
+                                self.remove_file(host, share_name, root)
+                            except Exception as e:
+                                print('\t[!] Unable to remove test file at \\\\%s\\%s\\%s, please remove manually' % (host, share_name, root))
+                        except Exception as e:
+                            exc_type, exc_obj, exc_tb = sys.exc_info()
+                            fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
+                            #print(exc_type, fname, exc_tb.tb_lineno)
+                            sys.stdout.flush()
 
                 try:
                     if self.smbconn[host].listPath(share_name, self.pathify('/')) and canWrite == False:
@@ -950,6 +967,14 @@ class SMBMap():
     def remove_dir(self, host, share, path):
         #path = self.pathify(path)
         self.smbconn[host].deleteDirectory(share, path)
+
+    def create_file(self, host, share, path):
+        tid = self.smbconn[host].connectTree(share)
+        self.smbconn[host].createFile(tid, path, desiredAccess=FILE_WRITE_DATA)
+
+    def remove_file(self, host, share, path):
+        #path = self.pathify(path)
+        self.smbconn[host].deleteFile(share, path)
 
     def valid_ip(self, address):
         try:


### PR DESCRIPTION
Currently smbmap checks if it can create a directory in a remote share to check if the user has **WRITE** permission.
The issue is that a share can restrict write permission to create files only, but not create directories. Here is an example:

![image](https://user-images.githubusercontent.com/11051803/103527681-02d30c00-4e83-11eb-9c78-2297cf57a50a.png)

Thus if creating an empty dir fails, smbmap shouldn't stop there and should try and create an empty file with minimal permissions (`FILE_WRITE_DATA`).

This pull request adds this feature to limit the number of false negative.

Before:
![image](https://user-images.githubusercontent.com/11051803/103528078-a8867b00-4e83-11eb-8bb6-4fccb468a8a7.png)

After:
![image](https://user-images.githubusercontent.com/11051803/103528127-b76d2d80-4e83-11eb-92ef-905bbe18a4ce.png)

(PS: These screenshots are using hackthebox RE box, which is retired, so it is not a spoil as the solution for this box has been officially released)