### PR TITLE
Remove -r/-R references from --csv usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ Shard drive Search:
   -g FILE               Output to a file in a grep friendly format, used with
                         -r or -R (otherwise it outputs nothing), ex -g
                         grep_out.txt
-  --csv FILE            Output to a CSV file, used with -r or -R (otherwise it
-                        outputs nothing), ex --csv shares.csv
+  --csv FILE            Output to a CSV file, ex --csv shares.csv
   --dir-only            List only directories, ommit files.
   --no-write-check      Skip check to see if drive grants WRITE access.
   -q                    Quiet verbose output. Only shows shares you have READ

--- a/smbmap.py
+++ b/smbmap.py
@@ -1207,7 +1207,7 @@ if __name__ == "__main__":
     mex_group3 = sgroup3.add_mutually_exclusive_group()
     mex_group3.add_argument("-A", metavar="PATTERN", dest="pattern", help="Define a file name pattern (regex) that auto downloads a file on a match (requires -R or -r), not case sensitive, ex '(web|global).(asax|config)'")
     mex_group3.add_argument("-g", metavar="FILE", dest="grepable", default=False, help="Output to a file in a grep friendly format, used with -r or -R (otherwise it outputs nothing), ex -g grep_out.txt")
-    mex_group3.add_argument("--csv", metavar="FILE", dest="csv", default=False, help="Output to a CSV file, used with -r or -R outputs file listings, ex --csv shares.csv")
+    mex_group3.add_argument("--csv", metavar="FILE", dest="csv", default=False, help="Output to a CSV file, ex --csv shares.csv")
     sgroup3.add_argument("--dir-only", dest='dir_only', action='store_true', help="List only directories, ommit files.")
     sgroup3.add_argument("--no-write-check", dest='write_check', action='store_false', help="Skip check to see if drive grants WRITE access.")
     sgroup3.add_argument("-q", dest="verbose", default=True, action="store_false", help="Quiet verbose output. Only shows shares you have READ or WRITE on, and suppresses file listing when performing a search (-A).")


### PR DESCRIPTION
The --csv option does not require the -r/-R options. This behavior was changed in 9a83288 (Enhanced CSV Export and Fixed Color Output to File, 2020-09-08). This request updates the usage statement to reflect that.
