### PR TITLE
Replace pycrypto with pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding = "utf-8") as fh:
 
 setuptools.setup(
     name = "smbmap",
-    version = "1.9.1",
+    version = "1.9.2",
     author = "ShawnDEvans",
     author_email = "Shawn.Evans@knowledgeCG.com",
     description = " SMBMap is a handy SMB enumeration tool ",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     install_requires = [
         'impacket',
         'pyasn1',
-        'pycrypto',
+        'pycryptodome',
         'configparser',
         'termcolor',
     ],


### PR DESCRIPTION
_pycrypto_ dependency is dead, the last version was released in 2013 and _pycryptodome_ is the actual mantained fork.
Using _pycrypto_ can cause compatibility issues, in this case I am unable to run the software.

I already built and tested the _smbmap_ module with the updated dependency and it works as expected.