### PR TITLE
Rename kereros to kerberos

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Main arguments:
   --timeout SCAN_TIMEOUT
                         Set port scan socket timeout. Default is .5 seconds
 
-Kereros settings:
+Kerberos settings:
   -k, --kerberos        Use Kerberos authentication
   --no-pass             Use CCache file (export KRB5CCNAME='~/current.ccache')
   --dc-ip IP or Host    IP or FQDN of DC

--- a/smbmap/smbmap.py
+++ b/smbmap/smbmap.py
@@ -1292,7 +1292,7 @@ def main():
     sgroup = parser.add_argument_group("Main arguments")
     mex_group = sgroup.add_mutually_exclusive_group(required=True)
     pass_group = sgroup.add_mutually_exclusive_group()
-    kerb_group = parser.add_argument_group('Kereros settings')
+    kerb_group = parser.add_argument_group('Kerberos settings')
     mex_group.add_argument("-H", metavar="HOST", dest='host', type=str, help="IP or FQDN", default=False)
     mex_group.add_argument("--host-file", metavar="FILE", dest="hostfile", default=False, type=argparse.FileType('r'), help="File containing a list of hosts")
 


### PR DESCRIPTION
While I was packaging this package for Debian, I noticed that kerberos was written incorrectly in two places, I made the adjustment there, and I'm adjusting it here as well.