### PR TITLE
Fixing -P option being ignored

### DIFF
--- a/smbmap/smbmap.py
+++ b/smbmap/smbmap.py
@@ -885,7 +885,7 @@ def find_open_ports(address):
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(PORT_SCAN_TIMEOUT)
-        result = sock.connect_ex((address, 445))
+        result = sock.connect_ex((address, smb_port))
         if result == 0:
             sock.close()
             return address
@@ -1230,7 +1230,7 @@ def login(host):
         if host['port'] == 445:
             smbconn = SMBConnection(host['ip'], host['ip'], sess_port=host['port'], timeout=3)
         else:
-            smbconn = SMBConnection('*SMBSERVER', host['host'], sess_port=host['port'], timeout=3)
+            smbconn = SMBConnection(host['ip'], host['ip'], sess_port=host['port'], timeout=3)
     except Exception as e:
         print('[!] Connection error on {}'.format(host['ip']))
 
@@ -1446,6 +1446,8 @@ def main():
                 print(f'[!] Name or service not known ({args.host})')
                 sys.exit(1)
 
+    global smb_port
+    smb_port = args.port
     mysmb.loader = Loader('Checking for open ports...')
     mysmb.loading = True
     mysmb.loader.start()


### PR DESCRIPTION
Seems that smbmap ignores the custom port passed via `-P`, still tries to connect to 445/tcp. This PR should fix it. I didn't test all functionalities, just basic use cases: connect and enumerate all shares content recursively.

Bear in mind that this is more a quick dirty patch than a long-term solution. There is probably a better way to do it than using a global variable, but I didn't have time to mess with the map calls.

Also, there are two reasons to explain the changes in line 1233:

- `host['ip']` instead of `host['host']` because it was throwing a missing key exception regarding `'host'`
- This line was also causing a connection error because it was trying to connect to NetBIOS port. Since one of the most common scenarios to provide a custom port would be when you are connecting to the target via some pivot point (e.g. port forwarding on an intermediate host), this wouldn't be always possible. So I dipped my toe into impacket SmbConnection class and seems that the change from `'*SMBSERVER'` to `'host['ip']` was the way to avoid this behavior.
- This change renders the if-else there redundant, I just keep it in case is needed for other features that I didn't test. If not, it can be removed.

Anyway, still feels hacky and probably need some improvements, but at least it works :)