### PR TITLE
Set PORT_SCAN_TIMEOUT globally

### DIFF
--- a/smbmap/smbmap.py
+++ b/smbmap/smbmap.py
@@ -882,6 +882,7 @@ def signal_handler(signal, frame):
 def find_open_ports(address):
     result = 1
     address = address.strip()
+    global PORT_SCAN_TIMEOUT
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(PORT_SCAN_TIMEOUT)
@@ -1369,6 +1370,7 @@ def main():
 
     if args.scan_timeout:
         if args.scan_timeout > 0 and args.scan_timeout < 10:
+            global PORT_SCAN_TIMEOUT
             PORT_SCAN_TIMEOUT = args.scan_timeout
 
     lsshare = False


### PR DESCRIPTION
Update PORT_SCAN_TIMEOUT globally to work as expected.