### PR TITLE
Dynamic terminal padding added

### DIFF
--- a/smbmap/smbmap.py
+++ b/smbmap/smbmap.py
@@ -104,6 +104,9 @@ class Loader(Thread):
     def resume(self):
         self.__flag.set()
 
+    def cleanup(self):
+        print(' ' * self._padding, end='\r')
+
     def calculate_padding(self):
         terminal_width = shutil.get_terminal_size((80, 24)).columns
         message_length = len(self._msg) + 10


### PR DESCRIPTION
Modified the Loader to accommodate different sized terminals. On smaller width terminals, the hardcoded padding would wrap and make the program output nearly unusable, by repeating the Loader print statement. With this change, no matter the terminal width, it should have a clean output on the Loader print.

Original Output on Small Terminal
![small_terminal](https://github.com/user-attachments/assets/ff5e0a8f-490b-4d28-860f-31346760a01b)

Original Output on Big Terminal
![big_terminal](https://github.com/user-attachments/assets/954c0e17-c999-4f4f-9318-e1318df1d1a4)

*Notice on a bigger terminal, it does not repeat lines*

Fixed Output on Small Terminal
![fixed_terminal](https://github.com/user-attachments/assets/f728a30c-8dd1-4afd-9daa-5f093f63068a)
